### PR TITLE
Provides ruby v2.2.8 (maybe - untested)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Provisioned with Ansible
 Includes:
 - nodejs
 - grunt-cli
-- ruby1.9.1
+- ruby2.2.8
 - bundler
 - bower
 - php55

--- a/provision.yml
+++ b/provision.yml
@@ -17,23 +17,23 @@
       - python
       - python-setuptools
       - python-software-properties
-      - ruby1.9.1
-      - ruby1.9.1-dev
-      - rubygems1.9.1
-      - irb1.9.1
-      - ri1.9.1
-      - rdoc1.9.1
+      - ruby2.2.8
+      - ruby2.2.8-dev
+      - rubygems2.2.8
+      - irb2.2.8
+      - ri2.2.8
+      - rdoc2.2.8
       - unzip
       - zip
       - sqlite3
       - libsqlite3-dev
       - gawk
 
-  - name: set ruby version to 1.9.1
-    command: update-alternatives --set ruby /usr/bin/ruby1.9.1
+  - name: set ruby version to 2.2.8
+    command: update-alternatives --set ruby /usr/bin/ruby2.2.8
 
-  - name: set gem version to 1.9.1
-    command: update-alternatives --set gem /usr/bin/gem1.9.1
+  - name: set gem version to 2.2.8
+    command: update-alternatives --set gem /usr/bin/gem2.2.8
 
   - name: install node apt repo
     apt_repository: repo=ppa:chris-lea/node.js state=present

--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -1,5 +1,5 @@
 name: astonish-wercker-box
-version: 0.2.23
+version: 0.2.24
 type: main
 platform: ubuntu@12.04
 description: Astonish Design standard Wercker Box
@@ -17,7 +17,7 @@ packages:
   - ansible@1.8.2
   - php@5.5
   - nodejs
-  - ruby@1.9.1
+  - ruby@2.2.8
   - mongoDB
   - phantomjs@1.9.7
   - uglify-js


### PR DESCRIPTION
The aim of this change is to bump ruby to 2.2.8 with minimal other wercker-box change, because older ruby is not building at wercker anymore.  v2.2.8 works in my localdev.